### PR TITLE
Fix mohawk version

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,2 +1,2 @@
-mohawk==2.3.4
+mohawk==0.3.4
 requests==1.0.2


### PR DESCRIPTION
Error:

```
(threatstack-python-client) [tom@tomcat:straycat threatstack-python-client(hawk_auth)*]$ pip install -r requirements.txt
Collecting mohawk==2.3.4 (from -r requirements.txt (line 1))
  Could not find a version that satisfies the requirement mohawk==2.3.4 (from -r requirements.txt (line 1)) (from versions: 0.0.1, 0.0.2, 0.0.3, 0.0.4, 0.1.0, 0.2.0, 0.2.1, 0.2.2, 0.3.0, 0.3.1, 0.3.2, 0.3.2.1, 0.3.3, 0.3.4)
No matching distribution found for mohawk==2.3.4 (from -r requirements.txt (line 1))
```